### PR TITLE
Import prototyped GTFS Consumer Application

### DIFF
--- a/AcTransitMap/Startup.cs
+++ b/AcTransitMap/Startup.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using MassTransit;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.HttpsPolicy;
@@ -25,6 +26,26 @@ namespace AcTransitMap
         {
             services.AddControllersWithViews();
 
+            services.AddMassTransit(cfg =>
+            {
+                cfg.AddBus(ConfigureBus);
+            });
+
+            services.AddMassTransitHostedService();
+
+        }
+
+        private IBusControl ConfigureBus(IBusRegistrationContext arg)
+        {
+            return Bus.Factory.CreateUsingRabbitMq(cfg =>
+            {
+                //TODO: Make host, user and pass env vars.
+                cfg.Host("rabbitmq.service", "/", rabbitCfg =>
+                 {
+                     rabbitCfg.Username("guest");
+                     rabbitCfg.Password("guest");
+                 });
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/GtfsConsumer.Entities/AcTransitStopEvent.cs
+++ b/GtfsConsumer.Entities/AcTransitStopEvent.cs
@@ -1,0 +1,11 @@
+﻿using GtfsConsumer.Entities.Interfaces;
+using System;
+
+namespace GtfsConsumer.Entities
+{
+    public class AcTransitStopEvent : IStopTimeEvent
+    {
+        public int Delay { get; set; }
+        public DateTime Timestamp { get; set; }
+    }
+}

--- a/GtfsConsumer.Entities/AcTransitStopTime.cs
+++ b/GtfsConsumer.Entities/AcTransitStopTime.cs
@@ -1,0 +1,12 @@
+﻿using GtfsConsumer.Entities.Interfaces;
+
+namespace GtfsConsumer.Entities
+{
+    public class AcTransitStopTime : IStopTimeUpdate
+    {
+        public string StopId { get; set; }
+        public IStopTimeEvent Arrival { get; set; }
+        public IStopTimeEvent Departure { get; set; }
+        public uint StopSequence { get; set; }
+    }
+}

--- a/GtfsConsumer.Entities/AcTransitTripDescriptor.cs
+++ b/GtfsConsumer.Entities/AcTransitTripDescriptor.cs
@@ -1,0 +1,16 @@
+﻿using GtfsConsumer.Entities.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GtfsConsumer.Entities
+{
+    public class AcTransitTripDescriptor : ITripDescriptor
+    {
+        public uint DirectionId { get; set; }
+        public string RouteId { get; set; }
+        public DateTime Start { get; set; }
+        public string TripId { get; set; }
+        public string SheduleType { get; set; }
+    }
+}

--- a/GtfsConsumer.Entities/AcTransitTripUpdate.cs
+++ b/GtfsConsumer.Entities/AcTransitTripUpdate.cs
@@ -1,0 +1,21 @@
+﻿using GtfsConsumer.Entities.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GtfsConsumer.Entities
+{
+    public class AcTransitTripUpdate : ITripUpdate
+    {
+
+        public int Delay { get; set; }
+
+        public DateTime Timestamp { get; set; }
+
+        public ITripDescriptor Trip { get; set; }
+
+        public IVehicleDescriptor Vehicle { get; set; }
+
+        public IEnumerable<IStopTimeUpdate> StopTimeUpdates { get; set; }
+    }
+}

--- a/GtfsConsumer.Entities/AcTransitVehicleDescriptor.cs
+++ b/GtfsConsumer.Entities/AcTransitVehicleDescriptor.cs
@@ -1,0 +1,11 @@
+﻿using GtfsConsumer.Entities.Interfaces;
+
+namespace GtfsConsumer.Entities
+{
+    public class AcTransitVehicleDescriptor : IVehicleDescriptor
+    {
+        public string Id { get; set; }
+        public string Label { get; set; }
+        public string LicensePlate { get; set; }
+    }
+}

--- a/GtfsConsumer.Entities/AcTransitVehiclePosition.cs
+++ b/GtfsConsumer.Entities/AcTransitVehiclePosition.cs
@@ -1,0 +1,20 @@
+﻿using GtfsConsumer.Entities.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GtfsConsumer.Entities
+{
+    public class AcTransitVehiclePosition : IVehiclePosition
+    {
+        public string StopId { get; set; }
+        public DateTime Timestamp { get; set; }
+        public ushort Bearing { get; set; }
+        public float Latitude { get; set; }
+        public float Longitude { get; set; }
+        public float Speed { get; set; }
+        public string VehicleId { get; set; }
+        public string RouteId { get; set; }
+        public string TripId { get; set; }
+    }
+}

--- a/GtfsConsumer.Entities/GtfsConsumer.Entities.csproj
+++ b/GtfsConsumer.Entities/GtfsConsumer.Entities.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/GtfsConsumer.Entities/Interfaces/IAlert.cs
+++ b/GtfsConsumer.Entities/Interfaces/IAlert.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GtfsConsumer.Interfaces
+{
+    public interface IAlert
+    {
+    }
+}

--- a/GtfsConsumer.Entities/Interfaces/IStopTimeEvent.cs
+++ b/GtfsConsumer.Entities/Interfaces/IStopTimeEvent.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace GtfsConsumer.Entities.Interfaces
+{
+    public interface IStopTimeEvent
+    {
+
+        int Delay { get; set; }
+
+        DateTime Timestamp { get; set; }
+
+    }
+}

--- a/GtfsConsumer.Entities/Interfaces/IStopTimeUpdate.cs
+++ b/GtfsConsumer.Entities/Interfaces/IStopTimeUpdate.cs
@@ -1,0 +1,15 @@
+﻿namespace GtfsConsumer.Entities.Interfaces
+{ 
+    public interface IStopTimeUpdate
+    {
+
+        string StopId { get; set; }
+
+        IStopTimeEvent Arrival { get; set; }
+
+        IStopTimeEvent Departure { get; set; }
+
+        uint StopSequence { get; set; }
+
+    }
+}

--- a/GtfsConsumer.Entities/Interfaces/ITripDescriptor.cs
+++ b/GtfsConsumer.Entities/Interfaces/ITripDescriptor.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace GtfsConsumer.Entities.Interfaces
+{
+    public interface ITripDescriptor
+    {
+
+        public uint DirectionId { get; set; }
+
+        public string RouteId { get; set; }
+
+        public DateTime Start { get; set; }
+
+        public string TripId { get; set; }
+
+        public string SheduleType { get; set; }
+
+    }
+}

--- a/GtfsConsumer.Entities/Interfaces/ITripUpdate.cs
+++ b/GtfsConsumer.Entities/Interfaces/ITripUpdate.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace GtfsConsumer.Entities.Interfaces
+{
+    public interface ITripUpdate
+    {
+        int Delay { get; set; }
+        DateTime Timestamp { get; set; }
+        ITripDescriptor Trip { get; set; }
+        IVehicleDescriptor Vehicle { get; set; }
+        IEnumerable<IStopTimeUpdate> StopTimeUpdates { get; set; }
+    }
+}

--- a/GtfsConsumer.Entities/Interfaces/IVehicleDescriptor.cs
+++ b/GtfsConsumer.Entities/Interfaces/IVehicleDescriptor.cs
@@ -1,0 +1,13 @@
+﻿namespace GtfsConsumer.Entities.Interfaces
+{
+    public interface IVehicleDescriptor
+    {
+
+        public string Id { get; set; }
+
+        public string Label { get; set; }
+
+        public string LicensePlate { get; set; }
+
+    }
+}

--- a/GtfsConsumer.Entities/Interfaces/IVehiclePosition.cs
+++ b/GtfsConsumer.Entities/Interfaces/IVehiclePosition.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace GtfsConsumer.Entities.Interfaces
+{
+    public interface IVehiclePosition
+    {
+
+        public string StopId { get; set; }
+
+        public DateTime Timestamp { get; set; }
+
+        public ushort Bearing { get; set; }
+
+        public float Latitude { get; set; }
+
+        public float Longitude { get; set; }
+
+        public float Speed { get; set; }
+
+        public string VehicleId { get; set; }
+
+        public string RouteId { get; set; }
+
+        public string TripId { get; set; }
+
+    }
+}

--- a/GtfsConsumer.Entities/Interfaces/IVehiclePositionUpdate.cs
+++ b/GtfsConsumer.Entities/Interfaces/IVehiclePositionUpdate.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace GtfsConsumer.Entities.Interfaces
+{
+    public interface IVehiclePositionUpdate
+    {
+
+        public List<IVehiclePosition> Positions { get; set; }
+
+    }
+}

--- a/GtfsConsumer/AcTransitConsumer.cs
+++ b/GtfsConsumer/AcTransitConsumer.cs
@@ -1,0 +1,124 @@
+﻿using GtfsConsumer.Entities;
+using GtfsConsumer.Entities.Interfaces;
+using GtfsConsumer.Interfaces;
+using ProtoBuf;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Threading.Tasks;
+using TransitRealtime;
+
+namespace GtfsConsumer
+{
+    public class AcTransitConsumer : ITransitConsumer
+    {
+        private readonly string _apiKey;
+
+        public AcTransitConsumer(string apiKey)
+        {
+            _apiKey = apiKey;
+        }
+
+        public async Task<IEnumerable<IVehiclePosition>> GetVehiclePositions()
+        {
+            WebRequest webReq = HttpWebRequest.Create($"https://api.actransit.org/transit/gtfsrt/vehicles?token={_apiKey}");
+            var response = await webReq.GetResponseAsync();
+            FeedMessage message = Serializer.Deserialize<FeedMessage>(response.GetResponseStream());
+            return FormVehiclePositions(message);
+        }
+
+        private IEnumerable<IVehiclePosition> FormVehiclePositions(FeedMessage message)
+        {
+            List<IVehiclePosition> outVar = new List<IVehiclePosition>();
+
+            foreach (var ent in message.Entities)
+            {
+                VehiclePosition pos = ent.Vehicle;
+                AcTransitVehiclePosition ourPos = new AcTransitVehiclePosition()
+                {
+                    Bearing = (ushort)pos.Position.Bearing,
+                    Latitude = pos.Position.Latitude,
+                    Longitude = pos.Position.Longitude,
+                    RouteId = pos.Trip?.RouteId,
+                    Speed = pos.Position.Speed,
+                    Timestamp = DateTime.UnixEpoch.AddSeconds(pos.Timestamp),
+                    StopId = pos.StopId,
+                    TripId = pos.Trip?.TripId,
+                    VehicleId = pos.Vehicle.Id
+                };
+                outVar.Add(ourPos);
+            }
+
+            return outVar;
+        }
+
+        public IEnumerable<IAlert> GetAlerts()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IEnumerable<ITripUpdate> GetTripUpdates()
+        {
+            WebRequest req = HttpWebRequest.Create($"https://api.actransit.org/transit/gtfsrt/tripupdates?token={_apiKey}");
+            FeedMessage message = Serializer.Deserialize<FeedMessage>(req.GetResponse().GetResponseStream());
+            return FormUpdates(message);
+        }
+
+        private IEnumerable<ITripUpdate> FormUpdates(FeedMessage message)
+        {
+            List<ITripUpdate> outVar = new List<ITripUpdate>();
+            foreach (var msg in message.Entities)
+            {
+                var trip = msg.TripUpdate;
+
+                ITripUpdate upd = new AcTransitTripUpdate()
+                {
+                    Delay = trip.Delay,
+                    Timestamp = DateTime.UnixEpoch.AddSeconds(trip.Timestamp),
+                    Trip = new AcTransitTripDescriptor()
+                    {
+                        TripId = trip.Trip.TripId,
+                        RouteId = trip.Trip.RouteId,
+                        SheduleType = trip.Trip.schedule_relationship.ToString(),
+                        DirectionId = trip.Trip.DirectionId
+                    },
+                    Vehicle = new AcTransitVehicleDescriptor()
+                    {
+                        Id = trip.Vehicle.Id,
+                        Label = trip.Vehicle.Label,
+                        LicensePlate = trip.Vehicle.LicensePlate
+                    },
+                    StopTimeUpdates = GetStopTimeUpdates(trip)
+                };
+                outVar.Add(upd);
+            }
+            return outVar;
+        }
+
+        private IEnumerable<IStopTimeUpdate> GetStopTimeUpdates(TripUpdate trip)
+        {
+            List<IStopTimeUpdate> stopTimeUpd = new List<IStopTimeUpdate>();
+            foreach (var stopTimes in trip.StopTimeUpdates)
+            {
+                IStopTimeUpdate stopTime = new AcTransitStopTime()
+                {
+                    StopId = stopTimes.StopId,
+                    Arrival = new AcTransitStopEvent()
+                    {
+                        Delay = stopTimes.Arrival.Delay,
+                        Timestamp = DateTime.UnixEpoch.AddSeconds(stopTimes.Arrival.Time)
+                    },
+                    Departure = new AcTransitStopEvent()
+                    {
+                        Delay = stopTimes.Departure.Delay,
+                        Timestamp = DateTime.UnixEpoch.AddSeconds(stopTimes.Departure.Time)
+                    }
+                };
+                stopTimeUpd.Add(stopTime);
+            }
+            return stopTimeUpd;
+        }
+
+
+    }
+}

--- a/GtfsConsumer/ConsumerApp.cs
+++ b/GtfsConsumer/ConsumerApp.cs
@@ -1,0 +1,49 @@
+﻿using GtfsConsumer.Entities;
+using GtfsConsumer.Entities.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace GtfsConsumer
+{
+    /// <summary>
+    /// This app consumes the GTFS RT feed from AC Transit and publishes it
+    /// to the message queue.
+    /// <para/>
+    /// In a sense it is both a consumer and a producer.
+    /// </summary>
+    public class ConsumerApp
+    {
+
+        static async Task Main(string[] args)
+        {
+
+            string apiKey = Environment.GetEnvironmentVariable("ACTRANSIT_KEY");
+            string user = Environment.GetEnvironmentVariable("RABBIT_USER");
+            string pass = Environment.GetEnvironmentVariable("RABBIT_PASS");
+
+            IConsumerBus consumer = new ConsumerBus("rabbitmq.service",user,pass);
+            await consumer.Start();
+
+            ITransitConsumer acTransit = new AcTransitConsumer(apiKey);
+
+            IEnumerable<IVehiclePosition> vehicles = await acTransit.GetVehiclePositions();
+
+            Console.WriteLine("Publishing");
+
+            foreach(IVehiclePosition pos in vehicles)
+            {
+                await consumer.Publish(pos);
+            }
+
+            try
+            {
+                Console.WriteLine("Done.");
+            }
+            finally
+            {
+                await consumer.Stop();
+            }
+        }
+    }
+}

--- a/GtfsConsumer/ConsumerBus.cs
+++ b/GtfsConsumer/ConsumerBus.cs
@@ -1,0 +1,45 @@
+﻿using GtfsConsumer.Entities.Interfaces;
+using MassTransit;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace GtfsConsumer
+{
+    public class ConsumerBus : IConsumerBus
+    {
+        private readonly IBusControl _bus;
+
+        public ConsumerBus(string host, string rabbitUser, string rabbitPass)
+        {
+            _bus = Bus.Factory.CreateUsingRabbitMq(bus =>
+            {
+                bus.Host(host, "/", rabbit =>
+                {
+                    rabbit.Username(rabbitUser);
+                    rabbit.Password(rabbitPass);
+                });
+                bus.Publish<IVehiclePositionUpdate>(x =>
+                {
+                    x.ExchangeType = "fanout";
+                });
+            });
+        }
+
+        public async Task Start()
+        {
+            await _bus.StartAsync();
+        }
+
+        public async Task Stop()
+        {
+            await _bus.StopAsync();
+        }
+
+        public async Task Publish<T>(T obj)
+        {
+            await _bus.Publish(obj);
+        }
+    }
+}

--- a/GtfsConsumer/Dockerfile
+++ b/GtfsConsumer/Dockerfile
@@ -1,0 +1,21 @@
+#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+
+FROM mcr.microsoft.com/dotnet/core/runtime:3.1-buster-slim AS base
+WORKDIR /app
+
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
+WORKDIR /src
+COPY ["GtfsConsumer/GtfsConsumer.csproj", "GtfsConsumer/"]
+COPY ["GtfsConsumer.Entities/GtfsConsumer.Entities.csproj", "GtfsConsumer.Entities/"]
+RUN dotnet restore "GtfsConsumer/GtfsConsumer.csproj"
+COPY . .
+WORKDIR "/src/GtfsConsumer"
+RUN dotnet build "GtfsConsumer.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "GtfsConsumer.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "GtfsConsumer.dll"]

--- a/GtfsConsumer/GtfsConsumer.csproj
+++ b/GtfsConsumer/GtfsConsumer.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="GtfsRealtimeBindings" Version="0.0.4" />
+    <PackageReference Include="MassTransit.RabbitMQ" Version="7.0.7" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.9" />
+    <PackageReference Include="protobuf-net" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\GtfsConsumer.Entities\GtfsConsumer.Entities.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/GtfsConsumer/IConsumerBus.cs
+++ b/GtfsConsumer/IConsumerBus.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+
+namespace GtfsConsumer
+{
+    public interface IConsumerBus
+    {
+        Task Publish<T>(T obj);
+        Task Start();
+        Task Stop();
+    }
+}

--- a/GtfsConsumer/ITransitConsumer.cs
+++ b/GtfsConsumer/ITransitConsumer.cs
@@ -1,0 +1,15 @@
+﻿using GtfsConsumer.Entities;
+using GtfsConsumer.Entities.Interfaces;
+using GtfsConsumer.Interfaces;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace GtfsConsumer
+{
+    public interface ITransitConsumer
+    {
+        IEnumerable<IAlert> GetAlerts();
+        IEnumerable<ITripUpdate> GetTripUpdates();
+        Task<IEnumerable<IVehiclePosition>> GetVehiclePositions();
+    }
+}

--- a/GtfsConsumer/Properties/launchSettings.json
+++ b/GtfsConsumer/Properties/launchSettings.json
@@ -1,0 +1,16 @@
+{
+  "profiles": {
+    "GtfsConsumer": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "RABBIT_USER": "guest",
+        "ACTRANSIT_KEY": "2C7DE00B1CC93558E4F7967C399C17A8",
+        "RABBIT_PASS": "guest"
+      },
+      "remoteDebugEnabled": false
+    },
+    "Docker": {
+      "commandName": "Docker"
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,3 +24,14 @@ services:
       interval: 30s
       timeout: 20s
       retries: 10
+
+  gtfsconsumer:
+    image: ${DOCKER_REGISTRY-}gtfsconsumer
+    build:
+      context: .
+      dockerfile: GtfsConsumer/Dockerfile
+    networks:
+      - app
+    environment:
+      - RABBIT_USER=guest
+      - RABBIT_PASS=guest


### PR DESCRIPTION
Add the previously prototyped gtfs-rt consumer to the solution. Currently reads gtfs-rt feeds once and exits.

Sends objects to the RabbitMQ container running on the compose network.