### PR TITLE
Implement changes to allow for running on a Kubernetes cluster 

### DIFF
--- a/AcTransitMap.Shared.Entities/AcTransitMap.Shared.Entities.csproj
+++ b/AcTransitMap.Shared.Entities/AcTransitMap.Shared.Entities.csproj
@@ -4,4 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="MassTransit.RabbitMQ" Version="7.0.7" />
+  </ItemGroup>
+
 </Project>

--- a/AcTransitMap.Shared.Entities/RabbitConnection.cs
+++ b/AcTransitMap.Shared.Entities/RabbitConnection.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AcTransitMap.Shared.Entities
+{
+    /// <summary>
+    /// An object to store RabbitMQ connection details.
+    /// </summary>
+    public class RabbitConnection
+    {
+        /// <summary>
+        /// The RabbitMQ endpoint/URL.
+        /// </summary>
+        public string Endpoint { get; set; }
+
+        /// <summary>
+        /// The username for the RabbitMQ user.
+        /// </summary>
+        public string Username { get; set; }
+
+        /// <summary>
+        /// The password for the RabbitMQ user.
+        /// </summary>
+        public string Password { get; set; }
+
+        /// <summary>
+        /// Sets the virtual host to use for RabbitMQ.
+        /// 
+        /// Defaults to <cd>"/"</cd>
+        /// </summary>
+        public string VirtualHost { get; set; } = "/";
+
+        /// <summary>
+        /// Returns whether or not the RabbitMQ connection details are valid.
+        /// <br/>
+        /// It's considered valid when the <see cref="Endpoint"/>, 
+        /// <see cref="Username"/> and <see cref="Password"/> are not null
+        /// or empty.
+        /// </summary>
+        /// <returns>Whether or not the RabbitMQ connection details are valid.</returns>
+        public bool IsValid()
+        {
+            return !string.IsNullOrEmpty(Endpoint) 
+                && !string.IsNullOrEmpty(Username)
+                && !string.IsNullOrEmpty(Password)
+                && !string.IsNullOrEmpty(VirtualHost);
+        }
+
+    }
+}

--- a/AcTransitMap.Shared.Entities/RabbitMqConnectionExtension.cs
+++ b/AcTransitMap.Shared.Entities/RabbitMqConnectionExtension.cs
@@ -1,0 +1,31 @@
+﻿using MassTransit;
+using MassTransit.RabbitMqTransport;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AcTransitMap.Shared.Entities
+{
+    public static class RabbitMqConnectionExtension
+    {
+
+        /// <summary>
+        /// Runs <see cref="IRabbitMqBusFactoryConfigurator.Host(string,string,RabbitMqHostSettings)"/>
+        /// with the specified <paramref name="connection"/> info.
+        /// </summary>
+        /// <param name="rabbit">The <see cref="IRabbitMqBusFactoryConfigurator"/> to configure</param>
+        /// <param name="connection">The <see cref="RabbitConnection"/> information
+        /// to connect with.</param>
+        public static void Host(this IRabbitMqBusFactoryConfigurator rabbit, RabbitConnection connection)
+        {
+            if (!connection.IsValid())
+                return;
+
+            rabbit.Host(connection.Endpoint,connection.VirtualHost, settings => {
+                settings.Username(connection.Username);
+                settings.Password(connection.Password);
+            });
+        }
+
+    }
+}

--- a/AcTransitMap/Startup.cs
+++ b/AcTransitMap/Startup.cs
@@ -58,7 +58,7 @@ namespace AcTransitMap
 
         private static void ConfigureRabbit(IBusRegistrationContext context, IRabbitMqBusFactoryConfigurator rabbit, string rabbitUser, string rabbitPass)
         {
-            rabbit.Host("rabbitmq.service", "/", rabbitCfg =>
+            rabbit.Host(Environment.GetEnvironmentVariable("RABBIT_URL"), "/", rabbitCfg =>
             {
                 rabbitCfg.Username(rabbitUser);
                 rabbitCfg.Password(rabbitPass);

--- a/GtfsConsumer/ConsumerApp.cs
+++ b/GtfsConsumer/ConsumerApp.cs
@@ -89,7 +89,8 @@ namespace GtfsConsumer
         {
             string rabbitUser = Environment.GetEnvironmentVariable("RABBIT_USER");
             string rabbitPass = Environment.GetEnvironmentVariable("RABBIT_PASS");
-            IConsumerBus consumer = new ConsumerBus("rabbitmq.service", rabbitUser, rabbitPass);
+            string rabbitUrl = Environment.GetEnvironmentVariable("RABBIT_URL");
+            IConsumerBus consumer = new ConsumerBus(rabbitUrl, rabbitUser, rabbitPass);
             await consumer.Start();
             return consumer;
         }

--- a/GtfsConsumer/ConsumerApp.cs
+++ b/GtfsConsumer/ConsumerApp.cs
@@ -27,8 +27,11 @@ namespace GtfsConsumer
             {
                 // Call every 30s
                 Log.Information("Beginning GTFS-RT gather timer.");
-                Timer timer = new Timer(new TimerCallback(service.Publish), null, 0, GetDelay());
-                await Task.Delay(Timeout.Infinite);
+                while (true) // God help me
+                {
+                    await service.Publish();
+                    await Task.Delay(GetDelay());
+                }
             } catch (Exception ex)
             {
                 Log.Error(ex, "Exception occured while publishing GTFS-RT feed: {ExceptionMessage}.", ex.Message);

--- a/GtfsConsumer/Dockerfile
+++ b/GtfsConsumer/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
 WORKDIR /src
 COPY ["GtfsConsumer/GtfsConsumer.csproj", "GtfsConsumer/"]
-COPY ["GtfsConsumer.Entities/GtfsConsumer.Entities.csproj", "GtfsConsumer.Entities/"]
+COPY ["AcTransitMap.Shared.Entities/AcTransitMap.Shared.Entities.csproj", "AcTransitMap.Shared.Entities/"]
 RUN dotnet restore "GtfsConsumer/GtfsConsumer.csproj"
 COPY . .
 WORKDIR "/src/GtfsConsumer"

--- a/GtfsConsumer/GtfsConsumer.csproj
+++ b/GtfsConsumer/GtfsConsumer.csproj
@@ -1,11 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk;Microsoft.NET.Sdk.Publish">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="GtfsRealtimeBindings" Version="0.0.4" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="7.0.7" />
@@ -15,9 +13,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\AcTransitMap.Shared.Entities\AcTransitMap.Shared.Entities.csproj" />
   </ItemGroup>
-
 </Project>

--- a/GtfsConsumer/Services/ConsumerService.cs
+++ b/GtfsConsumer/Services/ConsumerService.cs
@@ -27,7 +27,7 @@ namespace GtfsConsumer.Services
         /// GTFS feed and publishes it to the bus.
         /// </summary>
         /// <param name="state"></param>
-        public async void Publish(object state)
+        public async Task Publish()
         {
             Log.Information("Gathering GTFS-RT vehicle information");
             IEnumerable<IVehiclePosition> vehicles;

--- a/MessageProcessor/Dockerfile
+++ b/MessageProcessor/Dockerfile
@@ -7,7 +7,7 @@ FROM mcr.microsoft.com/dotnet/core/sdk:3.1-buster AS build
 WORKDIR /src
 COPY ["MessageProcessor/MessageProcessor.csproj", "MessageProcessor/"]
 COPY ["AcTransitMap.Database/AcTransitMap.Database.csproj", "AcTransitMap.Database/"]
-COPY ["GtfsConsumer.Entities/GtfsConsumer.Entities.csproj", "GtfsConsumer.Entities/"]
+COPY ["AcTransitMap.Shared.Entities/AcTransitMap.Shared.Entities.csproj", "AcTransitMap.Shared.Entities/"]
 RUN dotnet restore "MessageProcessor/MessageProcessor.csproj"
 COPY . .
 WORKDIR "/src/MessageProcessor"

--- a/MessageProcessor/IUpdaterService.cs
+++ b/MessageProcessor/IUpdaterService.cs
@@ -3,8 +3,21 @@ using System.Threading.Tasks;
 
 namespace MessageProcessor
 {
+    /// <summary>
+    /// A service for updating recieved <see cref="IVehiclePosition"/> messages.
+    /// <br/>
+    /// This service assumes that the messages pushed have already been validated
+    /// by the receiving consumer.
+    /// </summary>
     public interface IUpdaterService
     {
+        /// <summary>
+        /// Processes an <see cref="IVehiclePosition"/> message and 
+        /// sends it down the bus.
+        /// </summary>
+        /// <param name="message">The <see cref="IVehiclePosition"/> to validate 
+        /// and update.</param>
+        /// <returns>An awaitable task for processing and updating the message.</returns>
         Task Update(IVehiclePosition message);
     }
 }

--- a/MessageProcessor/MessageProcessor.csproj
+++ b/MessageProcessor/MessageProcessor.csproj
@@ -1,11 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk;Microsoft.NET.Sdk.Publish">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="MassTransit.Extensions.DependencyInjection" Version="7.0.7" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="7.0.7" />
@@ -15,10 +13,8 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\AcTransitMap.Database\AcTransitMap.Database.csproj" />
     <ProjectReference Include="..\AcTransitMap.Shared.Entities\AcTransitMap.Shared.Entities.csproj" />
   </ItemGroup>
-
 </Project>

--- a/MessageProcessor/Program.cs
+++ b/MessageProcessor/Program.cs
@@ -80,7 +80,7 @@ namespace MessageProcessor
 
         private static void ConfigureRabbit(IBusRegistrationContext context, IRabbitMqBusFactoryConfigurator rabbit, string rabbitUser, string rabbitPass)
         {
-            rabbit.Host("rabbitmq.service", "/", config =>
+            rabbit.Host(Environment.GetEnvironmentVariable("RABBIT_URL"), "/", config =>
             {
                 config.Username(rabbitUser);
                 config.Password(rabbitPass);

--- a/MessageProcessor/UpdaterService.cs
+++ b/MessageProcessor/UpdaterService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 namespace MessageProcessor
 {
+    /// <inheritdoc cref="IUpdaterService"/>
     public class UpdaterService : IUpdaterService
     {
 
@@ -19,6 +20,7 @@ namespace MessageProcessor
             _bus = bus;
         }
 
+        /// <inheritdoc/>
         public async Task Update(IVehiclePosition message)
         {
             IUpdatedVehiclePosition newVehiclePos = new UpdatedVehiclePosition()

--- a/MessageProcessor/VehiclePositionConsumer.cs
+++ b/MessageProcessor/VehiclePositionConsumer.cs
@@ -9,6 +9,13 @@ using System.Threading.Tasks;
 
 namespace MessageProcessor
 {
+    /// <summary>
+    /// A consumer for recieving raw <see cref="IVehiclePosition"/> messages
+    /// from the GTFS-RT source.
+    /// <br/>
+    /// Each message received is validated here before
+    /// being pushed through to the <see cref="IUpdaterService"/>.
+    /// </summary>
     public class VehiclePositionConsumer : IConsumer<IVehiclePosition>
     {
         private readonly IUpdaterService _updater;
@@ -18,6 +25,13 @@ namespace MessageProcessor
             _updater = updater;
         }
 
+        /// <summary>
+        /// Consumes the <see cref="IVehiclePosition"/> message and
+        /// if valid pushes it to the <see cref="IUpdaterService"/>.
+        /// </summary>
+        /// <param name="context">The <see cref="ConsumeContext"/> for the
+        /// current received message.</param>
+        /// <returns>An awaitable task for consuming a message.</returns>
         public async Task Consume(ConsumeContext<IVehiclePosition> context)
         {
             // Validate

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     environment:
       - RABBIT_PASS=${RABBIT_PASS}
       - RABBIT_USER=${RABBIT_USER}
+      - RABBIT_URL=rabbitmq.service
       - MONGO_CONNSTR=${MONGO_CONNSTR}
       - MONGO_DB=${MONGO_DB}
       - MONGO_COLLECTION=${MONGO_COLLECTION}
@@ -58,6 +59,7 @@ services:
     environment:
       - RABBIT_PASS=${RABBIT_PASS}
       - RABBIT_USER=${RABBIT_USER}
+      - RABBIT_URL=rabbitmq.service
       - SEQ_URL=${SEQ_URL}
       - ACTRANSIT_KEY=${ACTRANSIT_KEY}
       - FETCH_DELAY=15
@@ -75,6 +77,7 @@ services:
     environment:
       - RABBIT_PASS=${RABBIT_PASS}
       - RABBIT_USER=${RABBIT_USER}
+      - RABBIT_URL=rabbitmq.service
       - MONGO_CONNSTR=${MONGO_CONNSTR}
       - MONGO_DB=${MONGO_DB}
       - MONGO_COLLECTION=${MONGO_COLLECTION}


### PR DESCRIPTION
Some functionality, mainly the hard-coded RabbitMQ URL prevents the program from running on a Kubernetes cluster as only docker-compose uses service name to qualify to an endpoint URL.

Makes the RabbitMQ URL an environment variable and some other misc changes. 